### PR TITLE
add chi_tra_vert and chi_sim_vert to supported languages

### DIFF
--- a/internetarchiveocr/language.py
+++ b/internetarchiveocr/language.py
@@ -5,17 +5,18 @@ AUTOUSE_DETECTED_SCRIPTS = ('Fraktur', 'Kannada', 'Telugu', 'Tamil')
 # XXX: osd and equ are removed
 TESSERACT_LANGUAGE_CODES = {
     'afr', 'amh', 'ara', 'asm', 'aze', 'aze_cyrl', 'bel', 'ben', 'bod', 'bos',
-    'bre', 'bul', 'cat', 'ceb', 'ces', 'chi_sim', 'chi_tra', 'chr', 'cos',
-    'cym', 'dan', 'deu', 'div', 'dzo', 'ell', 'eng', 'enm', 'epo', 'est',
-    'eus', 'fas', 'fao', 'fil', 'fin', 'fra', 'frk', 'frm', 'fry', 'gla', 'gle',
-    'glg', 'grc', 'guj', 'hat', 'heb', 'hin', 'hrv', 'hun', 'hye', 'iku', 'ind',
-    'isl', 'ita', 'ita_old', 'jav', 'jpn', 'kan', 'kat', 'kat_old', 'kaz',
-    'khm', 'kir', 'kmr', 'kor', 'kor_vert', 'lao', 'lat', 'lav', 'lit', 'ltz',
-    'mal', 'mar', 'mkd', 'mlt', 'mon', 'mri', 'msa', 'mya', 'nep', 'nld', 'nor',
-    'oci', 'ori', 'pan', 'pol', 'por', 'pus', 'que', 'ron', 'rus', 'san',
-    'sin', 'slk', 'slv', 'snd', 'spa', 'spa_old', 'sqi', 'srp', 'srp_latn',
-    'sun', 'swa', 'swe', 'syr', 'tam', 'tat', 'tel', 'tgk', 'tha', 'tir', 'ton',
-    'tur', 'uig', 'ukr', 'urd', 'uzb', 'uzb_cyrl', 'vie', 'yid', 'yor',
+    'bre', 'bul', 'cat', 'ceb', 'ces', 'chi_sim', 'chi_sim_vert', 'chi_tra',
+    'chi_tra_vert', 'chr', 'cos', 'cym', 'dan', 'deu', 'div', 'dzo', 'ell',
+    'eng', 'enm', 'epo', 'est', 'eus', 'fas', 'fao', 'fil', 'fin', 'fra',
+    'frk', 'frm', 'fry', 'gla', 'gle', 'glg', 'grc', 'guj', 'hat', 'heb',
+    'hin', 'hrv', 'hun', 'hye', 'iku', 'ind', 'isl', 'ita', 'ita_old', 'jav',
+    'jpn', 'kan', 'kat', 'kat_old', 'kaz', 'khm', 'kir', 'kmr', 'kor',
+    'kor_vert', 'lao', 'lat', 'lav', 'lit', 'ltz', 'mal', 'mar', 'mkd', 'mlt',
+    'mon', 'mri', 'msa', 'mya', 'nep', 'nld', 'nor', 'oci', 'ori', 'pan',
+    'pol', 'por', 'pus', 'que', 'ron', 'rus', 'san', 'sin', 'slk', 'slv',
+    'snd', 'spa', 'spa_old', 'sqi', 'srp', 'srp_latn', 'sun', 'swa', 'swe',
+    'syr', 'tam', 'tat', 'tel', 'tgk', 'tha', 'tir', 'ton', 'tur', 'uig',
+    'ukr', 'urd', 'uzb', 'uzb_cyrl', 'vie', 'yid', 'yor',
     }
 
 TESSERACT_SCRIPT_CODES = {
@@ -159,8 +160,10 @@ LANGCODE_SCRIPT_MAP = {
     'cat': 'Latin',                 # Catalan: Latin
     'ceb': 'Latin',                 # Cebuano: Latin
     'ces': 'Latin',                 # Czech: Latin
-    'chi_sim': 'HanS',              # Chinese (simplified): Han TODO: Also HanS_vert?
-    'chi_tra': 'HanT',              # Chinese (traditional): Han TODO: Also HanT_vert?
+    'chi_sim': 'HanS',              # Chinese (simplified): HanS
+    'chi_sim_vert': 'HanS_vert',    # Chinese (simplified, vertical): HanS_vert
+    'chi_tra': 'HanT',              # Chinese (traditional): HanT
+    'chi_tra_vert': 'HanT_vert',    # Chinese (traditional, vertical): HanT_vert
     'chr': ('Cherokee', 'Latin'),   # Cherokee: Cherokee, Latin
     'cos': 'Latin',                 # Corsican: Latin
     'cym': 'Latin',                 # Welsh: Latin


### PR DESCRIPTION
Hi!

I am finding a way for the OCR to recognize Chinese in vertical writing before I upload tons of old books in Traditional Chinese to the IA, as I said in the email.

This PR simply adds `chi_tra_vert`/`HantT_vert`, `chi_sim_vert`/`HanS_vert` for this purpose. It does not change the existing language code mapping of `Chinese`, `Chinese (Simplified)` and etc. So there won't be breaking changes.

I plan to set `language = Chinese (Traditional)` and set `ocr_default_parameters = ocr_additional_languages:chi_tra_vert` on my books so that `-l chi_tra+chi_tra_vert` would be applied to Tesseract, which appears to be the only feasible way so far to recognize Traditional Chinese in either vertical or horizontal writing, even though it yields less accuracy in contrast to applied `-l chi_tra` or `-l chi_tra_vert` independently.

It might not be the right way to resolve the problem. But I think it is an acceptable workaround. I have also opened an issue in the upstream https://github.com/tesseract-ocr/tessdata_best/issues/72.